### PR TITLE
Update to use react 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "babel-runtime": "^5.5.6",
-    "react": "0.13.x"
+    "react": "^0.14.5"
   },
   "devDependencies": {
     "babel": "^5.5.6",

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var cx = require('./cx')
 
-var Badge = React.createClass({
+class Badge extends React.Component {
   render() {
     var extraClasses = []
     if (this.props.inverted) extraClasses.push('badge-inverted')
@@ -15,6 +15,6 @@ var Badge = React.createClass({
       />
     )
   }
-})
+}
 
 module.exports = Badge

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var cx = require('./cx')
 
-var Button = React.createClass({
+class Button extends React.Component {
   render() {
     var extraClasses = []
     if (this.props.block) extraClasses.push('btn-block')
@@ -18,6 +18,6 @@ var Button = React.createClass({
       />
     )
   }
-})
+}
 
 module.exports = Button

--- a/src/ControlItem.js
+++ b/src/ControlItem.js
@@ -1,8 +1,8 @@
 var React = require('react')
 var cx = require('./cx')
 
-var ControlItem = React.createClass({
-	render() {
+class ControlItem extends React.Component {
+    render() {
 		var classes = ['control-item'];
 		if (this.props.active) classes.push('active');
 		classes = classes.concat(this.props.className);
@@ -11,6 +11,6 @@ var ControlItem = React.createClass({
 			<a className={cx.apply(null, classes)}>{this.props.children}</a>	
 		);
 	}
-});
+}
 
 module.exports = ControlItem;

--- a/src/Icon.js
+++ b/src/Icon.js
@@ -1,14 +1,15 @@
 var React = require('react')
 var cx = require('./cx')
 
-var Icon = React.createClass({
-  getIconClasses(){
+class Icon extends React.Component {
+  getIconClasses() {
     var props = this.props
     return Object.keys(props)
       .filter((propName) => props[propName] === true)
       .map((iconName) => `icon-${iconName}`)
       .join(' ')
-  },
+  }
+
   render() {
     var {type} = this.props
     var typeClassName = type ? `icon-${type}` : null
@@ -19,6 +20,6 @@ var Icon = React.createClass({
       />
     )
   }
-})
+}
 
 module.exports = Icon

--- a/src/NavBar.js
+++ b/src/NavBar.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var cx = require('./cx')
 
-var NavBar = React.createClass({
+class NavBar extends React.Component {
   render() {
     return (
       <header
@@ -10,6 +10,6 @@ var NavBar = React.createClass({
       />
     )
   }
-})
+}
 
 module.exports = NavBar

--- a/src/NavButton.js
+++ b/src/NavButton.js
@@ -2,7 +2,7 @@ var React = require('react')
 var cx = require('./cx')
 var Icon = require('./Icon')
 
-var NavButton = React.createClass({
+class NavButton extends React.Component {
   render() {
     var side = this.props.right ? 'right' : 'left'
     var classes = cx(this.props.className, `btn-nav btn-link btn pull-${side}`)
@@ -27,6 +27,6 @@ var NavButton = React.createClass({
       )
     }
   }
-})
+}
 
 module.exports = NavButton

--- a/src/SegmentedControl.js
+++ b/src/SegmentedControl.js
@@ -1,14 +1,14 @@
 var React = require('react');
 var cx = require('./cx');
 
-var SegmentedControl = React.createClass({
-	render() {
+class SegmentedControl extends React.Component {
+    render() {
 		return (
 			<div className={cx('segmented-control', this.props.className)}>
 				{this.props.children}
 			</div>
 		);
 	}
-});
+}
 
 module.exports = SegmentedControl;

--- a/src/TableView.js
+++ b/src/TableView.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var cx = require('./cx')
 
-var TableView = React.createClass({
+class TableView extends React.Component {
   render() {
     return (
       <ul
@@ -10,6 +10,6 @@ var TableView = React.createClass({
       />
     )
   }
-})
+}
 
 module.exports = TableView

--- a/src/TableViewCell.js
+++ b/src/TableViewCell.js
@@ -1,7 +1,7 @@
 var React = require('react')
 var cx = require('./cx')
 
-var TableViewCell = React.createClass({
+class TableViewCell extends React.Component {
   getChevronDirection() {
     if (this.props.navigateLeft) {
       return 'left'
@@ -10,7 +10,8 @@ var TableViewCell = React.createClass({
     } else {
       return null
     }
-  },
+  }
+
   renderChildren() {
     var chevronDirection = this.getChevronDirection()
     if (this.props.href || chevronDirection) {
@@ -25,7 +26,8 @@ var TableViewCell = React.createClass({
     } else {
       return this.props.children
     }
-  },
+  }
+
   renderDivider() {
     return (
       <li
@@ -35,7 +37,8 @@ var TableViewCell = React.createClass({
         href={null}
       />
     )
-  },
+  }
+
   render() {
     if (this.props.divider) {
       return this.renderDivider()
@@ -49,6 +52,6 @@ var TableViewCell = React.createClass({
       />
     )
   }
-})
+}
 
 module.exports = TableViewCell

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,10 +1,10 @@
 var React = require('react')
 var cx = require('./cx')
 
-var Title = React.createClass({
+class Title extends React.Component {
   render() {
     return <h1 {...this.props} className={cx(this.props.className, "title")} />
   }
-})
+}
 
 module.exports = Title

--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -5,10 +5,10 @@ var Toggle = React.createClass({
   componentDidMount() {
     // ensure ratchet toggles initialised
     require('../vendor/toggles')
-    this.refs.toggle.getDOMNode().addEventListener('toggle', this.handleToggle)
+    React.findDOMNode(this.refs.toggle).addEventListener('toggle', this.handleToggle)
   },
   componentWillUnmount() {
-    this.refs.toggle.getDOMNode().removeEventListener('toggle', this.handleToggle)
+    React.findDOMNode(this.refs.toggle).removeEventListener('toggle', this.handleToggle)
   },
   handleToggle(e) {
     var inverse = !this.props.active

--- a/src/Toggle.js
+++ b/src/Toggle.js
@@ -1,21 +1,29 @@
 var React = require('react')
 var cx = require('./cx')
 
-var Toggle = React.createClass({
+class Toggle extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.handleToggle = this.handleToggle.bind(this);
+  }
+
   componentDidMount() {
     // ensure ratchet toggles initialised
     require('../vendor/toggles')
     React.findDOMNode(this.refs.toggle).addEventListener('toggle', this.handleToggle)
-  },
+  }
+
   componentWillUnmount() {
     React.findDOMNode(this.refs.toggle).removeEventListener('toggle', this.handleToggle)
-  },
+  }
+
   handleToggle(e) {
     var inverse = !this.props.active
     if (e.detail.isActive == inverse) {
       this.props.onToggle(inverse)
     }
-  },
+  }
+
   render() {
     var extraClasses = []
     if (this.props.active) extraClasses.push('active')
@@ -27,6 +35,6 @@ var Toggle = React.createClass({
       </div>
     )
   }
-})
+}
 
 module.exports = Toggle


### PR DESCRIPTION
I ran the following [official react codemod](https://github.com/reactjs/react-codemod/blob/master/README.md) scripts:
- `findDOMNode`
- `class`

This is the result. It solves my major issue, which was the use of the old-style classes. They return the following sort of error under 0.14:

```
React component classes must extend React.Component.
```

So. Hopefully this is useful to others! Fixes #5.
